### PR TITLE
Fixes #60 by removing unintentional error reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Usage: reapp-run [options]
   -p, --port [number]  specify a port [number]
   -h, --host [host]    specify hostname
   -b, --bind [address] specify bind address if different from host
-  -e, --env [env]      specify an enivornment
+  -e, --env [env]      specify an environment
   -t, --tool [tool]    specify a webpack devtool
 ```
 

--- a/lib/findConfig.js
+++ b/lib/findConfig.js
@@ -55,7 +55,6 @@ function getDefaultConfig(opts) {
   if (opts.debug) {
     console.log('No user config found...'.blue);
     console.log('Looking for default config: ', defaultConfigPath);
-    console.log(e, "\n");
   }
 
   return require(defaultConfigPath);


### PR DESCRIPTION
This change will once again allow debugging of a reapp app using the -d switch (or running repp-debug). Because the `e` var was out of scope in the called function, the default reapp-pack config file was not being loaded in the absence of a local config file.
