### PR TITLE
If custom config throws as error treat it as such.

### DIFF
--- a/lib/findConfig.js
+++ b/lib/findConfig.js
@@ -55,7 +55,7 @@ module.exports = function(opts) {
   // global config
   var globalConfig;
 
-  config = requireFirst([
+  globalConfig = requireFirst([
     opts.dir + '/config/all.config.js',
     opts.dir + '/all.config.js'
   ], function() {

--- a/lib/findConfig.js
+++ b/lib/findConfig.js
@@ -1,5 +1,34 @@
+var fs = require('fs')
 var pack = require('reapp-pack');
 require('reapp-object-assign');
+
+function moduleExists(path) {
+  try {
+    require.resolve(path);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function requireFirst(paths, getDefault) {
+  if (typeof getDefault === 'undefined') {
+    getDefault = function() { return null; };
+  }
+  if (paths.length === 0) {
+    return getDefault();
+  }
+
+  // Try to resolve all alternatives except the last one
+  var path, i;
+  for (i = 0; i < paths.length; i++) {
+    path = paths[i];
+    if (moduleExists(path)) {
+      return require(path);
+    }
+  }
+  return getDefault();
+}
 
 module.exports = function(opts) {
   var config;
@@ -16,29 +45,22 @@ module.exports = function(opts) {
   if (opts.debug)
     console.log('Looking for config file: %s'.blue, configName);
 
-  try {
-    config = require(opts.dir + '/config/' + configName);
-  }
-  catch(e) {
-    try {
-      config = require(opts.dir + '/' + configName)
-    } catch(e) {
-      config = getDefaultConfig(opts);
-    }
-  }
+  config = requireFirst([
+    opts.dir + '/config/' + configName,
+    opts.dir + '/' + configName
+  ], function() {
+    return getDefaultConfig(opts);
+  });
 
   // global config
   var globalConfig;
 
-  try {
-    globalConfig = require(opts.dir + '/config/all.config.js');
-  }
-  catch(e) {
-    try {
-      globalConfig = require(opts.dir + '/all.config.js');
-    }
-    catch(e) {}
-  }
+  config = requireFirst([
+    opts.dir + '/config/all.config.js',
+    opts.dir + '/all.config.js'
+  ], function() {
+    return null;
+  });
 
   if (globalConfig) {
     config = Object.assign({}, globalConfig, config);


### PR DESCRIPTION
Fixes #72 
When a custom config file throws an error, reapp treated it as if the config
file was not found, printed an error message saying as much and went on to try
the default config file inside reapp-pack.
